### PR TITLE
[UI/UX] Change asterisk to exclamation mark

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -652,7 +652,7 @@ class AbstractArgView extends React.PureComponent<AbstractArgViewProps, {}> {
           <input readOnly type="checkbox" checked={!!argValue} />
           <span title={arg.description} style={{color: '#8B2BB9'}}>
             {arg.name}
-            {isRequiredArgument(arg) ? '*' : ''}:
+            {isRequiredArgument(arg) ? '!' : ''}:
           </span>
         </span>{' '}
         {input}


### PR DESCRIPTION
Change asterisk to exclamation mark for non-nullable fields that is a common in the GraphQL world.

Before:

![before](https://user-images.githubusercontent.com/7892779/53151466-607a4a00-35c4-11e9-9fd5-65b844be32b1.png)

After:

![after](https://user-images.githubusercontent.com/7892779/53151479-6839ee80-35c4-11e9-8fff-b0dbdcb004b3.png)
