### PR TITLE
Improve accessibility across the board

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -154,20 +154,20 @@ const defaultColors: Colors = {
 };
 
 const defaultArrowOpen = (
-  <svg width="12" height="9">
+  <svg width="12" height="9" style={{marginLeft: '3px'}}>
     <path fill="#666" d="M 0 2 L 9 2 L 4.5 7.5 z" />
   </svg>
 );
 
 const defaultArrowClosed = (
-  <svg width="12" height="9">
+  <svg width="12" height="9" style={{marginLeft: '3px'}}>
     <path fill="#666" d="M 0 0 L 0 9 L 5.5 4.5 z" />
   </svg>
 );
 
 const defaultCheckboxChecked = (
   <svg
-    style={{marginRight: '3px', marginLeft: '-3px'}}
+    style={{marginRight: '3px'}}
     width="12"
     height="12"
     viewBox="0 0 18 18"
@@ -182,7 +182,7 @@ const defaultCheckboxChecked = (
 
 const defaultCheckboxUnchecked = (
   <svg
-    style={{marginRight: '3px', marginLeft: '-3px'}}
+    style={{marginRight: '3px'}}
     width="12"
     height="12"
     viewBox="0 0 18 18"

--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1787,7 +1787,7 @@ class Explorer extends React.PureComponent<Props, State> {
           fontFamily:
             'Consolas, Inconsolata, "Droid Sans Mono", Monaco, monospace',
         }}
-        className="grapihql-explorer-root">
+        className="graphiql-explorer-root">
         {relevantOperations.map(
           (
             operation: OperationDefinitionNode | FragmentDefinitionNode,


### PR DESCRIPTION
This pull request focuses on improving the keyboard and screen reader operability of the data explorer by making the following changes and then a few more:

- Each individual query is now implemented as a named region, making it easier to navigate between queries using a screen reader.

- The field and variable tree is now implemented as a nested unordered list, communicating proper semantics to users of assistive technologies. The individual lists have also been assigned accessible names to make it easy to identity their purpose and association to their parent, such as "Fields for type" or "Variables for field". Do let me know if I got the terminology right 😄 

- All interactive components are now implemented as `<button>` elements, ensuring that they correctly communicate to users of assistive technology that they can be interacted with and that standard keyboard interaction works as expected.

- The state of fields and variables is now communicated to users of assistive technologies, such as if they're expanded (using `aria-expanded`) or selected (using `aria-selected`).