### PR TITLE
add a 'deprecated' class to fields which have been marked as such

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1233,8 +1233,14 @@ class FieldView extends React.PureComponent<FieldViewProps, {}> {
     const selection = this._getSelection();
     const type = unwrapOutputType(field.type);
     const args = field.args.sort((a, b) => a.name.localeCompare(b.name));
+    let className = 'graphiql-explorer-node';
+    
+    if (field.isDeprecated) {
+      className += ' deprecated';
+    }
+
     const node = (
-      <div className="graphiql-explorer-node">
+      <div className={className}>
         <span
           title={field.description}
           style={{


### PR DESCRIPTION
This allows more flexible styling of deprecated fields, e.g. using the following CSS to strikethrough the deprecated fields:
```css
.graphiql-explorer-node.deprecated {
  span {
    span {
      text-decoration: line-through;
      font-style: italic;
    }
  }
}
```