### PR TITLE
Additional polish

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1434,7 +1434,7 @@ const defaultStyles = {
 
 type RootViewProps = {|
   schema: GraphQLSchema,
-  isLast: Boolean,
+  isLast: boolean,
   fields: ?GraphQLFieldMap<any, any>,
   operation: OperationType,
   name: ?string,
@@ -1805,7 +1805,7 @@ class Explorer extends React.PureComponent<Props, State> {
           style={styleConfig.styles.buttonStyle}
           type="link"
           value={('query': NewOperationType)}>
-          Query
+          New Query
         </option>
       ) : null,
       !!mutationFields ? (
@@ -1814,7 +1814,7 @@ class Explorer extends React.PureComponent<Props, State> {
           style={styleConfig.styles.buttonStyle}
           type="link"
           value={('mutation': NewOperationType)}>
-          Mutation
+          New Mutation
         </option>
       ) : null,
       !!subscriptionFields ? (
@@ -1823,7 +1823,7 @@ class Explorer extends React.PureComponent<Props, State> {
           style={styleConfig.styles.buttonStyle}
           type="link"
           value={('subscription': NewOperationType)}>
-          Subscription
+          New Subscription
         </option>
       ) : null,
     ].filter(Boolean);
@@ -1869,6 +1869,8 @@ class Explorer extends React.PureComponent<Props, State> {
           </div>
         </div>
       );
+
+    const attribution = this.props.showAttribution ? <Attribution /> : null;
 
     return (
       <div
@@ -1976,6 +1978,7 @@ class Explorer extends React.PureComponent<Props, State> {
               );
             },
           )}
+          {attribution}
         </div>
 
         {actionsEl}
@@ -2020,7 +2023,6 @@ class ExplorerWrapper extends React.PureComponent<Props, {}> {
   };
 
   render() {
-    const attribution = this.props.showAttribution ? <Attribution /> : null;
     return (
       <div
         className="docExplorerWrap"
@@ -2048,7 +2050,6 @@ class ExplorerWrapper extends React.PureComponent<Props, {}> {
           <ErrorBoundary>
             <Explorer {...this.props} />
           </ErrorBoundary>
-          {attribution}
         </div>
       </div>
     );

--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1836,7 +1836,7 @@ class Explorer extends React.PureComponent<Props, State> {
             maxHeight: '50px',
             overflow: 'none',
           }}>
-          <div
+          <form
             className="variable-editor-title graphiql-explorer-actions"
             style={{
               ...styleConfig.styles.explorerActionsStyle,
@@ -1844,14 +1844,16 @@ class Explorer extends React.PureComponent<Props, State> {
               flexDirection: 'row',
               alignItems: 'center',
               borderTop: '1px solid rgb(214, 214, 214)',
-            }}>
+            }}
+            onSubmit={event => event.preventDefault()}>
             <select
               onChange={event => this._setAddOperationType(event.target.value)}
               value={this.state.newOperationType}
-              style={{flexGrow: '9'}}>
+              style={{flexGrow: '2'}}>
               {actionsOptions}
             </select>
             <button
+              type="submit"
               className="toolbar-button"
               onClick={() =>
                 this.state.newOperationType
@@ -1861,12 +1863,11 @@ class Explorer extends React.PureComponent<Props, State> {
               style={{
                 ...styleConfig.styles.buttonStyle,
                 height: '22px',
-                flexGrow: '1',
-                width: 'unset',
+                width: '22px',
               }}>
               <span>+</span>
             </button>
-          </div>
+          </form>
         </div>
       );
 
@@ -2018,7 +2019,7 @@ class ErrorBoundary extends React.Component<
 class ExplorerWrapper extends React.PureComponent<Props, {}> {
   static defaultValue = defaultValue;
   static defaultProps = {
-    width: 380,
+    width: 320,
     title: 'Explorer',
   };
 
@@ -2027,8 +2028,9 @@ class ExplorerWrapper extends React.PureComponent<Props, {}> {
       <div
         className="docExplorerWrap"
         style={{
-          maxHeight: '100%',
+          height: '100%',
           width: this.props.width,
+          minWidth: this.props.width,
           zIndex: 7,
           display: this.props.explorerIsOpen ? 'flex' : 'none',
           flexDirection: 'column',
@@ -2046,7 +2048,12 @@ class ExplorerWrapper extends React.PureComponent<Props, {}> {
         </div>
         <div
           className="doc-explorer-contents"
-          style={{padding: '0px', overflowY: 'unset'}}>
+          style={{
+            padding: '0px',
+            /* Unset overflowY since docExplorerWrap sets it and it'll
+            cause two scrollbars (one for the container and one for the schema tree) */
+            overflowY: 'unset',
+          }}>
           <ErrorBoundary>
             <Explorer {...this.props} />
           </ErrorBoundary>

--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1868,7 +1868,7 @@ class Explorer extends React.PureComponent<Props, State> {
           },
         )}
         <div
-          className="variable-editor-title"
+          className="variable-editor-title graphiql-explorer-actions"
           style={styleConfig.styles.explorerActionsStyle}>
           {!!queryFields ? (
             <button
@@ -1942,15 +1942,15 @@ class ExplorerWrapper extends React.PureComponent<Props, {}> {
     const attribution = this.props.showAttribution ? <Attribution /> : null;
     return (
       <div
-        className="historyPaneWrap"
+        className="docExplorerWrap"
         style={{
           height: '100%',
           width: this.props.width,
           zIndex: 7,
           display: this.props.explorerIsOpen ? 'block' : 'none',
         }}>
-        <div className="history-title-bar">
-          <div className="history-title">{this.props.title}</div>
+        <div className="doc-explorer-title-bar">
+          <div className="doc-explorer-title">{this.props.title}</div>
           <div className="doc-explorer-rhs">
             <div
               className="docExplorerHide"
@@ -1959,7 +1959,7 @@ class ExplorerWrapper extends React.PureComponent<Props, {}> {
             </div>
           </div>
         </div>
-        <div className="history-contents">
+        <div className="doc-explorer-contents">
           <div
             style={{
               overflow: 'scroll',

--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1234,9 +1234,9 @@ class FieldView extends React.PureComponent<FieldViewProps, {}> {
     const type = unwrapOutputType(field.type);
     const args = field.args.sort((a, b) => a.name.localeCompare(b.name));
     let className = 'graphiql-explorer-node';
-    
+
     if (field.isDeprecated) {
-      className += ' deprecated';
+      className += ' graphiql-explorer-deprecated';
     }
 
     const node = (
@@ -1267,7 +1267,11 @@ class FieldView extends React.PureComponent<FieldViewProps, {}> {
               styleConfig={this.props.styleConfig}
             />
           )}
-          <span style={{color: styleConfig.colors.property}}>{field.name}</span>
+          <span
+            style={{color: styleConfig.colors.property}}
+            className="graphiql-explorer-field-view">
+            {field.name}
+          </span>
         </span>
         {selection && args.length ? (
           <div style={{marginLeft: 16}}>


### PR DESCRIPTION
- Deprecated fields have a special class name for styling
  - This works for some users' needs now, but I think in the future we should actually allow a function as a prop that’ll be given the field and determine any class names, so we could add a beta field instead of the deprecated field
- Fix buttons at the bottom for less scrolling, and they also take up less space
- `__typename` will be automatically removed if it’s not the only field selection (only at the top level) and added back in if there are no other fields (this will solve one of my trip ups when giving live talks when the operation goes away when unselecting all fields)

Preview of the new explorer: https://www.dropbox.com/s/b9nrgxl87h0xhly/graphiql_polish.mp4?dl=0