### PR TITLE
Actions reword and auto scroll on add

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql-explorer",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql-explorer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql-explorer",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "homepage": "https://github.com/onegraph/graphiql-explorer",
   "bugs": {
     "url": "https://github.com/onegraph/graphiql-explorer/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql-explorer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "https://github.com/onegraph/graphiql-explorer",
   "bugs": {
     "url": "https://github.com/onegraph/graphiql-explorer/issues"

--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1796,6 +1796,20 @@ class Explorer extends React.PureComponent<Props, State> {
       };
 
       this.props.onEdit(print(newOperationDef));
+
+      const framesToWait = 5;
+      // This is inherently racey, but if it fails it's not a huge deal.
+      setTimeout(
+        () => {
+          // Optimistically try to scroll to the newly added operation
+          var selector = `.graphiql-explorer-root #${kind}-${newOperationName}`;
+
+          var el = document.querySelector(selector);
+          el && el.scrollIntoView();
+        },
+        // five "frames" to have inserted the element
+        16 * framesToWait,
+      );
     };
 
     const actionsOptions = [
@@ -1805,7 +1819,7 @@ class Explorer extends React.PureComponent<Props, State> {
           style={styleConfig.styles.buttonStyle}
           type="link"
           value={('query': NewOperationType)}>
-          New Query
+          Query
         </option>
       ) : null,
       !!mutationFields ? (
@@ -1814,7 +1828,7 @@ class Explorer extends React.PureComponent<Props, State> {
           style={styleConfig.styles.buttonStyle}
           type="link"
           value={('mutation': NewOperationType)}>
-          New Mutation
+          Mutation
         </option>
       ) : null,
       !!subscriptionFields ? (
@@ -1823,7 +1837,7 @@ class Explorer extends React.PureComponent<Props, State> {
           style={styleConfig.styles.buttonStyle}
           type="link"
           value={('subscription': NewOperationType)}>
-          New Subscription
+          Subscription
         </option>
       ) : null,
     ].filter(Boolean);
@@ -1846,6 +1860,14 @@ class Explorer extends React.PureComponent<Props, State> {
               borderTop: '1px solid rgb(214, 214, 214)',
             }}
             onSubmit={event => event.preventDefault()}>
+            <span
+              style={{
+                display: 'inline-block',
+                flexGrow: '0',
+                textAlign: 'right',
+              }}>
+              Add new{' '}
+            </span>
             <select
               onChange={event => this._setAddOperationType(event.target.value)}
               value={this.state.newOperationType}

--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -126,6 +126,7 @@ type NewOperationType = 'query' | 'mutation' | 'subscription';
 type State = {|
   operation: ?OperationDefinitionNode,
   newOperationType: NewOperationType,
+  operationToScrollTo: ?string,
 |};
 
 type Selections = $ReadOnlyArray<SelectionNode>;
@@ -1445,6 +1446,7 @@ type RootViewProps = {|
   ) => void,
   onOperationRename: (query: string) => void,
   onRunOperation: (name: ?string) => void,
+  onMount: (rootViewElId: string) => void,
   getDefaultFieldNames: (type: GraphQLObjectType) => Array<string>,
   getDefaultScalarArgValue: GetDefaultScalarArgValue,
   makeDefaultArg: ?MakeDefaultArg,
@@ -1516,15 +1518,28 @@ class RootView extends React.PureComponent<RootViewProps, {}> {
     }
   };
 
+  _rootViewElId = () => {
+    const {operation, name} = this.props;
+    const rootViewElId = `${operation}-${name || 'unknown'}`;
+    return rootViewElId;
+  };
+
+  componentDidMount() {
+    const rootViewElId = this._rootViewElId();
+
+    this.props.onMount(rootViewElId);
+  }
+
   render() {
     const {
       operation,
-      name,
       definition,
       schema,
       getDefaultFieldNames,
       styleConfig,
     } = this.props;
+    const rootViewElId = this._rootViewElId();
+
     const fields = this.props.fields || {};
     const operationDef = definition;
     const selections = operationDef.selectionSet.selections;
@@ -1534,7 +1549,7 @@ class RootView extends React.PureComponent<RootViewProps, {}> {
 
     return (
       <div
-        id={`${operation}-${name || 'unknown'}`}
+        id={rootViewElId}
         style={{
           // The actions bar has its own top border
           borderBottom: this.props.isLast ? 'none' : '1px solid #d6d6d6',
@@ -1626,7 +1641,11 @@ class Explorer extends React.PureComponent<Props, State> {
     getDefaultScalarArgValue: defaultGetDefaultScalarArgValue,
   };
 
-  state = {newOperationType: 'query', operation: null};
+  state = {
+    newOperationType: 'query',
+    operation: null,
+    operationToScrollTo: null,
+  };
 
   _ref: ?any;
   _resetScroll = () => {
@@ -1643,6 +1662,18 @@ class Explorer extends React.PureComponent<Props, State> {
 
   _setAddOperationType = (value: NewOperationType) => {
     this.setState({newOperationType: value});
+  };
+
+  _handleRootViewMount = (rootViewElId: string) => {
+    if (
+      !!this.state.operationToScrollTo &&
+      this.state.operationToScrollTo === rootViewElId
+    ) {
+      var selector = `.graphiql-explorer-root #${rootViewElId}`;
+
+      var el = document.querySelector(selector);
+      el && el.scrollIntoView();
+    }
   };
 
   render() {
@@ -1795,26 +1826,15 @@ class Explorer extends React.PureComponent<Props, State> {
         definitions: newDefinitions,
       };
 
+      this.setState({operationToScrollTo: `${kind}-${newOperationName}`});
+
       this.props.onEdit(print(newOperationDef));
-
-      const framesToWait = 5;
-      // This is inherently racey, but if it fails it's not a huge deal.
-      setTimeout(
-        () => {
-          // Optimistically try to scroll to the newly added operation
-          var selector = `.graphiql-explorer-root #${kind}-${newOperationName}`;
-
-          var el = document.querySelector(selector);
-          el && el.scrollIntoView();
-        },
-        // five "frames" to have inserted the element
-        16 * framesToWait,
-      );
     };
 
     const actionsOptions = [
       !!queryFields ? (
         <option
+          key="query"
           className={'toolbar-button'}
           style={styleConfig.styles.buttonStyle}
           type="link"
@@ -1824,6 +1844,7 @@ class Explorer extends React.PureComponent<Props, State> {
       ) : null,
       !!mutationFields ? (
         <option
+          key="mutation"
           className={'toolbar-button'}
           style={styleConfig.styles.buttonStyle}
           type="link"
@@ -1833,6 +1854,7 @@ class Explorer extends React.PureComponent<Props, State> {
       ) : null,
       !!subscriptionFields ? (
         <option
+          key="subscription"
           className={'toolbar-button'}
           style={styleConfig.styles.buttonStyle}
           type="link"
@@ -1972,6 +1994,7 @@ class Explorer extends React.PureComponent<Props, State> {
                   definition={operation}
                   onOperationRename={onOperationRename}
                   onTypeName={fragmentTypeName}
+                  onMount={this._handleRootViewMount}
                   onEdit={newDefinition => {
                     const newQuery = {
                       ...parsedQuery,


### PR DESCRIPTION
Slight rewords the action panel (as requested by Hasura folks), and auto-scrolls to a newly-added action (if it's inserted in 80ms, otherwise no-op).

![Screenshot 2020-01-21 13 57 52](https://user-images.githubusercontent.com/35296/72846796-22fbc200-3c56-11ea-9e6d-8c7f36359046.png)
