### PR TITLE
[PoC] Add support of custom GraphQL scalars

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -737,34 +737,54 @@ class AbstractArgView extends React.PureComponent<AbstractArgViewProps, {}> {
           </span>
         );
       } else if (isScalarType(argType)) {
-        if (argType.name === 'Boolean') {
-          input = (
-            <select
-              style={{
-                color: styleConfig.colors.builtin,
-              }}
-              onChange={this.props.setArgValue}
-              value={
-                argValue.kind === 'BooleanValue' ? argValue.value : undefined
-              }>
-              <option key="true" value="true">
-                true
-              </option>
-              <option key="false" value="false">
-                false
-              </option>
-            </select>
-          );
-        } else {
-          input = (
-            <ScalarInput
-              setArgValue={this.props.setArgValue}
-              arg={arg}
-              argValue={argValue}
-              onRunOperation={this.props.onRunOperation}
-              styleConfig={this.props.styleConfig}
-            />
-          );
+        switch (argType.name) {
+          case 'Boolean':
+            input = (
+              <select
+                style={{
+                  color: styleConfig.colors.builtin,
+                }}
+                onChange={this.props.setArgValue}
+                value={
+                  argValue.kind === 'BooleanValue' ? argValue.value : undefined
+                }>
+                <option key="true" value="true">
+                  true
+                </option>
+                <option key="false" value="false">
+                  false
+                </option>
+              </select>
+            );
+            break;
+          case 'HexColorCode':
+            input = (
+              <input
+                type="color"
+                value={argValue.value}
+                onChange={this.props.setArgValue}
+              />
+            );
+            break;
+          case 'Date':
+            input = (
+              <input
+                type="date"
+                value={argValue.value}
+                onChange={this.props.setArgValue}
+              />
+            );
+            break;
+          default:
+            input = (
+              <ScalarInput
+                setArgValue={this.props.setArgValue}
+                arg={arg}
+                argValue={argValue}
+                onRunOperation={this.props.onRunOperation}
+                styleConfig={this.props.styleConfig}
+              />
+            );
         }
       } else if (isEnumType(argType)) {
         if (argValue.kind === 'EnumValue') {


### PR DESCRIPTION
This pull request is proof of concept of using native HTML `<input>` element for adding support of custom GraphQL scalars into Explorer. It adds support of common `Date` and `HexColorCode` custom scalars.

![graphiql-explorer-date-custom-scalar-input-day](https://user-images.githubusercontent.com/7892779/73520397-9bac0c80-4414-11ea-8570-ddbeb1b8abd0.png)

![graphiql-explorer-date-custom-scalar-input-month](https://user-images.githubusercontent.com/7892779/73520403-9ea6fd00-4414-11ea-88f4-4be6ce15c8dc.png)

![graphiql-explorer-hexcolorcode-custom-scalar-input-rgb](https://user-images.githubusercontent.com/7892779/73520411-a23a8400-4414-11ea-923e-987d27591c01.png)

![graphiql-explorer-hexcolorcode-custom-scalar-input-hsl](https://user-images.githubusercontent.com/7892779/73520415-a49cde00-4414-11ea-9ca5-3fc0ed061d08.png)