### PR TITLE
[UX] Place arguments into round brackets

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -1883,25 +1883,29 @@ class FieldView extends React.PureComponent<
           )}
         </span>
         {selection && args.length ? (
-          <div
-            style={{marginLeft: 16}}
-            className="graphiql-explorer-graphql-arguments">
-            {args.map(arg => (
-              <ArgView
-                key={arg.name}
-                parentField={field}
-                arg={arg}
-                selection={selection}
-                modifyArguments={this._setArguments}
-                getDefaultScalarArgValue={this.props.getDefaultScalarArgValue}
-                makeDefaultArg={this.props.makeDefaultArg}
-                onRunOperation={this.props.onRunOperation}
-                styleConfig={this.props.styleConfig}
-                onCommit={this.props.onCommit}
-                definition={this.props.definition}
-              />
-            ))}
-          </div>
+          <React.Fragment>
+            <div style={{display: 'inline', marginLeft: '3px'}}>{'('}</div>
+            <div
+              style={{marginLeft: 16}}
+              className="graphiql-explorer-graphql-arguments">
+              {args.map(arg => (
+                <ArgView
+                  key={arg.name}
+                  parentField={field}
+                  arg={arg}
+                  selection={selection}
+                  modifyArguments={this._setArguments}
+                  getDefaultScalarArgValue={this.props.getDefaultScalarArgValue}
+                  makeDefaultArg={this.props.makeDefaultArg}
+                  onRunOperation={this.props.onRunOperation}
+                  styleConfig={this.props.styleConfig}
+                  onCommit={this.props.onCommit}
+                  definition={this.props.definition}
+                />
+              ))}
+            </div>
+            <div>{')'}</div>
+          </React.Fragment>
         ) : null}
       </div>
     );


### PR DESCRIPTION
This pull request improves user experience by visually separating the input fields from the output fields by placing arguments into round brackets:

![before-after](https://user-images.githubusercontent.com/7892779/80133301-b3270b80-85a5-11ea-90e1-345f9108b669.png)
