### PR TITLE
Add key to fix unique key error

### DIFF
--- a/src/Explorer.js
+++ b/src/Explorer.js
@@ -2761,6 +2761,7 @@ class Explorer extends React.PureComponent<Props, State> {
 
               return (
                 <RootView
+                  key={index}
                   isLast={index === relevantOperations.length - 1}
                   fields={fields}
                   operationType={operationType}


### PR DESCRIPTION
I got `Warning: Each child in an array or iterator should have a unique "key" prop` error on React 16.13.1.
This PR fixes the problem.

If someone wants a quick fix, use https://github.com/ds300/patch-package and apply the below patch.

`graphiql-explorer+0.6.2.patch`
```
diff --git a/node_modules/graphiql-explorer/dist/Explorer.js b/node_modules/graphiql-explorer/dist/Explorer.js
index 5c8ce51..579f418 100644
--- a/node_modules/graphiql-explorer/dist/Explorer.js
+++ b/node_modules/graphiql-explorer/dist/Explorer.js
@@ -2475,6 +2475,7 @@ var Explorer = function (_React$PureComponent9) {
             };
 
             return React.createElement(RootView, {
+              key: index,
               isLast: index === relevantOperations.length - 1,
               fields: fields,
               operationType: operationType,

```